### PR TITLE
Clear up keyvault downloads in the HTTP server

### DIFF
--- a/source/lv2/httpd/httpd_keyvault.c
+++ b/source/lv2/httpd/httpd_keyvault.c
@@ -85,7 +85,7 @@ int response_keyvault_process_request(struct http_state *http, const char *metho
 
 	priv->hdr_state = 0;
 	priv->ptr = 0;
-	if (sfc.initialized == SFCX_INITIALIZED && !rawBlockMode && !decrypted)
+	if (sfc.initialized == SFCX_INITIALIZED && rawBlockMode && !decrypted)
 		priv->len = bytes_sz;
 	else
 		priv->len = KV_FLASH_SIZE;

--- a/source/lv2/httpd/httpd_keyvault.c
+++ b/source/lv2/httpd/httpd_keyvault.c
@@ -90,8 +90,10 @@ int response_keyvault_process_request(struct http_state *http, const char *metho
 	else
 		priv->len = KV_FLASH_SIZE;
 	priv->togo = priv->len;
-	if (!decrypted)
+	if (!decrypted && rawBlockMode)
 		priv->filename="keyvault_raw.bin";
+	else if (!decrypted)
+		priv->filename="keyvault_enc.bin";
 	else
 		priv->filename="keyvault.bin";
 	http->code = 200;

--- a/source/lv2/httpd/httpd_keyvault.c
+++ b/source/lv2/httpd/httpd_keyvault.c
@@ -35,11 +35,13 @@ int response_keyvault_process_request(struct http_state *http, const char *metho
 	if (strcmp(method, "GET"))
 		return 0;
 
+	rawBlockMode = 0;
+	decrypted = 0;
 	if (strcmp(url, "/KVRAW") && strcmp(url, "/KVRAW2") && strcmp(url, "/KV"))
 		return 0;
-	if (!(strcmp(url, "/KVRAW2") && !(strcmp(url, "/KV"))))
+	if (strcmp(url, "/KVRAW2") == 0)
 		rawBlockMode = 1;
-	if (strcmp(url, "/KV"))
+	if (strcmp(url, "/KV") == 0)
 		decrypted = 1;
 
 	http->response_priv = mem_malloc(sizeof(struct response_mem_priv_s));
@@ -50,7 +52,7 @@ int response_keyvault_process_request(struct http_state *http, const char *metho
 	int bytes_sz = (KV_FLASH_SIZE / sfc.page_sz) * sfc.page_sz_phys;
 
 	//priv->base = (void*) 0x80000200c8000000ULL;
-	if (sfc.initialized == SFCX_INITIALIZED && !rawBlockMode)
+	if (sfc.initialized == SFCX_INITIALIZED && rawBlockMode && !decrypted)
 		priv->base = (void*) mem_malloc(bytes_sz);
 	else
 		priv->base = (void*) mem_malloc(KV_FLASH_SIZE);
@@ -61,15 +63,15 @@ int response_keyvault_process_request(struct http_state *http, const char *metho
 	}
 
 	
-	if (sfc.initialized == SFCX_INITIALIZED && !rawBlockMode && !decrypted)
+	if (sfc.initialized == SFCX_INITIALIZED && rawBlockMode && !decrypted) // KVRAW2
 	{
 		int i = 0;
 		for (i = 0; i < (bytes_sz / sfc.page_sz_phys); i++)		
 			sfcx_read_page(priv->base + (i * sfc.page_sz_phys), KV_FLASH_SIZE + (i * sfc.page_sz), 1);		
 	}
-	else if (!decrypted)
+	else if (!decrypted) // KVRAW
 		xenon_get_logical_nand_data(priv->base, KV_FLASH_OFFSET, KV_FLASH_SIZE);
-	else
+	else // KV
 	{
 		if(kv_read(priv->base,0)!=0) 
 			if(kv_read(priv->base,1)!=0){ // Try decrypt with virtual cpukey 
@@ -83,7 +85,7 @@ int response_keyvault_process_request(struct http_state *http, const char *metho
 
 	priv->hdr_state = 0;
 	priv->ptr = 0;
-	if (sfc.initialized == SFCX_INITIALIZED && !rawBlockMode)
+	if (sfc.initialized == SFCX_INITIALIZED && !rawBlockMode && !decrypted)
 		priv->len = bytes_sz;
 	else
 		priv->len = KV_FLASH_SIZE;


### PR DESCRIPTION
Commit [1a5afd6](https://github.com/Free60Project/xell-reloaded/commit/1a5afd651a2ec7b41a95ea1cee8934683170bfb0) brought in a logic error where `/KV` no longer downloaded the decrypted keyvault (like expected from the wording on the index page.)

This fixes it up and has easier to understand URLs.

`/KV` will download `keyvault.bin`, a 16KB file of the decrypted keyvault.
`/KVRAW` will download `keyvault_enc.bin`, a 16KB file of the raw keyvault data, still encrypted.
`/KVRAW2` will download `keyvault_raw.bin`, a 16.5KB file of the raw keyvault data, plus what I assume is ECC? (I don't know the purpose of this, nor will it function properly on 4GB Corona. I just left it in assuming it's some use to somebody, otherwise it wouldn't have been added, right?)