### PR TITLE
Re-enable the XTAF driver

### DIFF
--- a/Makefile_lv2.mk
+++ b/Makefile_lv2.mk
@@ -37,7 +37,7 @@ LDFLAGS	=	-g $(MACHDEP) -Wl,--gc-sections -Wl,-Map,$(notdir $@).map
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	-lxenon -lm -lfat # -lext2fs -lntfs -lxtaf
+LIBS	:=	-lxenon -lm -lfat -lxtaf # -lext2fs -lntfs
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/source/lv2/config.h
+++ b/source/lv2/config.h
@@ -18,7 +18,7 @@
 //#define FS_ISO9660
 #define FS_FAT
 //#define FS_EXT2FS
-//#define FS_XTAF
+#define FS_XTAF
 //#define FS_NTFS
 
 void mount_all_devices();

--- a/source/lv2/file.c
+++ b/source/lv2/file.c
@@ -119,6 +119,7 @@ int try_load_file(char *filename, int filetype) {
   printf("Trying %s...\r", filename);
 
   struct stat s;
+  memset(&s, 0, sizeof(struct stat));
   stat(filename, &s);
 
   long size = s.st_size;


### PR DESCRIPTION
The XTAF driver is functional as of Free60Project/libxtaf#1 and I've been able to load a kboot.conf configuration as well as a xenon.elf file from the main storage partition of the 360 Hard Disk.

Related: #18 