### PR TITLE
Enable the ISO9660 driver

### DIFF
--- a/source/lv2/config.h
+++ b/source/lv2/config.h
@@ -15,7 +15,7 @@
 
 /* Filesystem drivers */
 
-//#define FS_ISO9660
+#define FS_ISO9660
 #define FS_FAT
 //#define FS_EXT2FS
 #define FS_XTAF


### PR DESCRIPTION
ISO9660 driver in libxenon has been fixed since https://github.com/Free60Project/libxenon/commit/6b1743dd00d00ec57dda14e572211f0866d5aab6

Tested booting ubuntu-10.10-xenon-lxde-light-b5.iso off a burned CD-R - works:

<img width="822" height="220" alt="image" alt="XeLL Reloaded console output displaying 'Trying dvd0:/vmlinux' followed by '* dvd0:/vmlinux found, loading 9619212...'" src="https://github.com/user-attachments/assets/4eb34806-40ed-4db5-9b06-42df0d62398d" />

See also #18 