### PR TITLE
RRQ error fix, validate fallback_address connectivity, cleanup tftp error prints

### DIFF
--- a/source/lv2/main.c
+++ b/source/lv2/main.c
@@ -219,11 +219,11 @@ int main(){
 		// your router must support switching tftp OR you have a pure layer 2 setup
 
 		// Stop trying the fallback_server after 3 tries ~30 seconds of no response.
-		if(arp_timeout_count <= TFTP_MAX_RETRIES){
+		if(arp_timeout_count <= 3){
 			// Primarily a developer feature, set fallback_address IP to your tftp server.
 			tftp_loop(fallback_address);
 			arp_timeout_count++;
-			if(arp_timeout_count == TFTP_MAX_RETRIES)
+			if(arp_timeout_count == 3)
 				printf("Error! Exceeded retries for fallback server. Ensure the server is online with port 69 open.\n");
 		}
 

--- a/source/lv2/main.c
+++ b/source/lv2/main.c
@@ -115,7 +115,7 @@ int main(){
 #elif defined DEFAULT_THEME
 	console_set_colors(CONSOLE_COLOR_BLUE,CONSOLE_COLOR_WHITE); // White text on blue bg
 #else
-	console_set_colors(CONSOLE_COLOR_BLACK,CONSOLE_COLOR_PINK); // Pink text on black bg
+	console_set_colors(CONSOLE_COLOR_BLACK,CONSOLE_COLOR_GREEN); // Green text on black bg
 #endif
 	console_init();
 
@@ -206,10 +206,10 @@ int main(){
 	//			i = device_list_size;
 	//	}
 	//}
-	
+
 	// mount_all_devices();
 	ip_addr_t fallback_address;
-	ip4_addr_set_u32(&fallback_address, 0xC0A801FE); // 192.168.1.254
+	ip4_addr_set_u32(&fallback_address, 0xC0A8015A); // 192.168.1.90
 
 	printf("\n * Looking for files on TFTP...\n\n");
 	int arp_timeout_count = 0;
@@ -221,14 +221,14 @@ int main(){
 		// Stop trying the fallback_server after 3 tries ~30 seconds of no response.
 		if(arp_timeout_count <= TFTP_MAX_RETRIES){
 			// Primarily a developer feature, set fallback_address IP to your tftp server.
-			tftp_loop(fallback_address); 
+			tftp_loop(fallback_address);
 			arp_timeout_count++;
-			if(arp_timeout_count == TFTP_MAX_RETRIES) 
+			if(arp_timeout_count == TFTP_MAX_RETRIES)
 				printf("Error! Exceeded retries for fallback server. Ensure the server is online with port 69 open.\n");
 		}
 
 		fileloop();
-		
+
 		console_clrline();
 	}
 

--- a/source/lv2/tftp/tftp.c
+++ b/source/lv2/tftp/tftp.c
@@ -20,7 +20,8 @@
 #include <network/network.h>
 #include <ppc/timebase.h>
 
-#define TFTP_MAX_RETRIES 2
+// +1 to support latent network links.
+#define TFTP_MAX_RETRIES 3
 
 #define TFTP_STATE_RRQ_SEND 0
 #define TFTP_STATE_DATA_RECV 1
@@ -77,6 +78,7 @@ int send_ack(struct udp_pcb *pcb, ip_addr_t server_addr, uint16_t port, uint32_t
     rc = -1;
   }
 
+  console_clrline();
   pbuf_free(p);
   return rc;
 }
@@ -120,13 +122,13 @@ static int send_rrq(struct udp_pcb *pcb, ip_addr_t server_addr, uint16_t port,
 
     d += sprintf((char*)d, "%i", block_size);
   }
-
+  
   if (udp_sendto(pcb, p, &server_addr, port) != 0) {
-    console_clrline();
     printf("TFTP: Failed to send RRQ packet.\n");
     rc = -1;
   }
 
+  console_clrline();
   pbuf_free(p);
   return rc;
 }
@@ -250,6 +252,7 @@ static void tftp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p,
 
       send_ack(tftp_state->pcb, *addr, port, 0);
     }
+    console_clrline();
   } break;
 
   case TFTP_OPCODE_ERROR: {

--- a/source/lv2/tftp/tftp.c
+++ b/source/lv2/tftp/tftp.c
@@ -73,7 +73,7 @@ int send_ack(struct udp_pcb *pcb, ip_addr_t server_addr, uint16_t port, uint32_t
   *(uint16_t *)(d + 2) = block;
 
   if (udp_sendto(pcb, p, &server_addr, port)) {
-    printf("TFTP: Failed to send ACK packet.\n");
+    printf("TFTP: Failed to send ACK packet.\n\r");
     rc = -1;
   }
 
@@ -123,7 +123,7 @@ static int send_rrq(struct udp_pcb *pcb, ip_addr_t server_addr, uint16_t port,
 
   if (udp_sendto(pcb, p, &server_addr, port) != 0) {
     console_clrline();
-    printf("TFTP: Failed to send RRQ packet.\n");
+    printf("TFTP: Failed to send RRQ packet.\r");
     rc = -1;
   }
 

--- a/source/lv2/tftp/tftp.c
+++ b/source/lv2/tftp/tftp.c
@@ -252,7 +252,6 @@ static void tftp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p,
 
       send_ack(tftp_state->pcb, *addr, port, 0);
     }
-    console_clrline();
   } break;
 
   case TFTP_OPCODE_ERROR: {
@@ -262,6 +261,7 @@ static void tftp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p,
     /* please don't overflow this. */
     console_clrline();
     printf("tftp error %d: %s\n", (d[2] << 8) | d[3], d + 4);
+    console_clrline();
   } break;
 
   default: {

--- a/source/lv2/tftp/tftp.c
+++ b/source/lv2/tftp/tftp.c
@@ -260,7 +260,11 @@ static void tftp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p,
 
     /* please don't overflow this. */
     console_clrline();
+<<<<<<< Updated upstream
     printf("tftp error %d: %s\n", (d[2] << 8) | d[3], d + 4);
+=======
+    printf("tftp error %d: %s\n\r", (d[2] << 8) | d[3], d + 4);
+>>>>>>> Stashed changes
     console_clrline();
   } break;
 

--- a/source/lv2/tftp/tftp.c
+++ b/source/lv2/tftp/tftp.c
@@ -20,8 +20,7 @@
 #include <network/network.h>
 #include <ppc/timebase.h>
 
-// +1 to support latent network links.
-#define TFTP_MAX_RETRIES 3
+#define TFTP_MAX_RETRIES 2
 
 #define TFTP_STATE_RRQ_SEND 0
 #define TFTP_STATE_DATA_RECV 1
@@ -78,7 +77,6 @@ int send_ack(struct udp_pcb *pcb, ip_addr_t server_addr, uint16_t port, uint32_t
     rc = -1;
   }
 
-  console_clrline();
   pbuf_free(p);
   return rc;
 }
@@ -122,13 +120,13 @@ static int send_rrq(struct udp_pcb *pcb, ip_addr_t server_addr, uint16_t port,
 
     d += sprintf((char*)d, "%i", block_size);
   }
-  
+
   if (udp_sendto(pcb, p, &server_addr, port) != 0) {
+    console_clrline();
     printf("TFTP: Failed to send RRQ packet.\n");
     rc = -1;
   }
 
-  console_clrline();
   pbuf_free(p);
   return rc;
 }
@@ -260,8 +258,7 @@ static void tftp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p,
 
     /* please don't overflow this. */
     console_clrline();
-    printf("tftp error %d: %s\n\r", (d[2] << 8) | d[3], d + 4);
-    console_clrline();
+    printf("tftp error %d: %s\r", (d[2] << 8) | d[3], d + 4);
   } break;
 
   default: {
@@ -343,7 +340,7 @@ int do_tftp(void *target, int maxlen, struct ip_addr server, const char *file) {
   }
 
   if (tftp_state.state == TFTP_STATE_ERROR) {
-    printf("TFTP error: %s\n", tftp_state.error_msg);
+    printf("TFTP error: %s\n\r", tftp_state.error_msg);
     
     if (tftp_state.server_port != 0) {
       // Notify the server.

--- a/source/lv2/tftp/tftp.c
+++ b/source/lv2/tftp/tftp.c
@@ -260,11 +260,7 @@ static void tftp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p,
 
     /* please don't overflow this. */
     console_clrline();
-<<<<<<< Updated upstream
-    printf("tftp error %d: %s\n", (d[2] << 8) | d[3], d + 4);
-=======
     printf("tftp error %d: %s\n\r", (d[2] << 8) | d[3], d + 4);
->>>>>>> Stashed changes
     console_clrline();
   } break;
 


### PR DESCRIPTION
Reviving this from work last night and this morning. Was able to add a function to main to send a few ARP requests to the specified fallback_address for tftpboot. If the ARP request goes unanswered then tftp_loop is not even tried since there is no point and fileloop begins. Tested fully and working for intended fixes.