### PR TITLE
Add flag to enable/disable TFTP support

### DIFF
--- a/source/lv2/config.h
+++ b/source/lv2/config.h
@@ -12,6 +12,7 @@
 //#define NO_PRINT_CONFIG         //commented to display config
 //#define NO_NETWORKING		//commented to actually use networking...
 //#define NO_DVD				//commented to actually use the DVD...
+#define NO_TFTP
 
 /* Filesystem drivers */
 #define FS_ISO9660
@@ -19,7 +20,6 @@
 //#define FS_EXT2FS
 #define FS_XTAF
 //#define FS_NTFS
-#define FS_TFTP
 
 void mount_all_devices();
 

--- a/source/lv2/config.h
+++ b/source/lv2/config.h
@@ -12,7 +12,7 @@
 //#define NO_PRINT_CONFIG         //commented to display config
 //#define NO_NETWORKING		//commented to actually use networking...
 //#define NO_DVD				//commented to actually use the DVD...
-#define NO_TFTP
+//#define NO_TFTP
 
 /* Filesystem drivers */
 #define FS_ISO9660

--- a/source/lv2/config.h
+++ b/source/lv2/config.h
@@ -14,12 +14,12 @@
 //#define NO_DVD				//commented to actually use the DVD...
 
 /* Filesystem drivers */
-
 #define FS_ISO9660
 #define FS_FAT
 //#define FS_EXT2FS
 #define FS_XTAF
 //#define FS_NTFS
+#define FS_TFTP
 
 void mount_all_devices();
 

--- a/source/lv2/main.c
+++ b/source/lv2/main.c
@@ -215,7 +215,9 @@ int main(){
 	ip4_addr_set_u32(&fallback_address, 0xC0A8015A); // 192.168.1.90
 
 #ifndef NO_TFTP
-	printf("\n * Looking for files on TFTP...\n\n");
+	printf("\n * Looking for files on TFTP and local media...\n\n");
+#else
+	printf("\n * Looking for files on local media...\n\n");
 #endif
 
    for(;;){
@@ -226,7 +228,7 @@ int main(){
       #else
          // If TFTP support isn't enabled
          // the network still needs to be
-         // poll'ed for the web interface 
+         // polled for the web interface 
          network_poll();
       #endif
 

--- a/source/lv2/main.c
+++ b/source/lv2/main.c
@@ -32,7 +32,7 @@
 #include "config.h"
 #include "file.h"
 
-#ifdef FS_TFTP
+#ifndef NO_TFTP
 #include "tftp/tftp.h"
 #endif
 
@@ -214,12 +214,12 @@ int main(){
 	ip_addr_t fallback_address;
 	ip4_addr_set_u32(&fallback_address, 0xC0A8015A); // 192.168.1.90
 
-#ifdef FS_TFTP
+#ifndef NO_TFTP
 	printf("\n * Looking for files on TFTP...\n\n");
 #endif
 
    for(;;){
-      #ifdef FS_TFTP
+      #ifndef NO_TFTP
          //less likely to find something...
 		   tftp_loop(boot_server_name());
 		   tftp_loop(fallback_address);

--- a/source/lv2/main.c
+++ b/source/lv2/main.c
@@ -31,7 +31,10 @@
 #include "asciiart.h"
 #include "config.h"
 #include "file.h"
+
+#ifdef FS_TFTP
 #include "tftp/tftp.h"
+#endif
 
 #include "log.h"
 
@@ -211,12 +214,23 @@ int main(){
 	ip_addr_t fallback_address;
 	ip4_addr_set_u32(&fallback_address, 0xC0A8015A); // 192.168.1.90
 
+#ifdef FS_TFTP
 	printf("\n * Looking for files on TFTP...\n\n");
-	for(;;){
-		tftp_loop(boot_server_name()); //less likely to find something...
-		tftp_loop(fallback_address);
+#endif
+
+   for(;;){
+      #ifdef FS_TFTP
+         //less likely to find something...
+		   tftp_loop(boot_server_name());
+		   tftp_loop(fallback_address);
+      #else
+         // If TFTP support isn't enabled
+         // the network still needs to be
+         // poll'ed for the web interface 
+         network_poll();
+      #endif
+
 		fileloop();
-		
 		console_clrline();
 	}
 


### PR DESCRIPTION
Being that TFTP support has some issues (most visibly with the RRQ errors that are spammed to the console), I found it very useful to have a method to disable TFTP support but retain functionality of the WebUI.

I've been using code equivalent to the "no TFTP support" case in my own fork of XeLL without any ill effects.