### PR TITLE
Reset ROL state before xenon_smc_start_bootanim

### DIFF
--- a/source/lv2/main.c
+++ b/source/lv2/main.c
@@ -98,6 +98,10 @@ int main(){
 	*(volatile uint32_t*)0xea001064 = 0x10;
 	*(volatile uint32_t*)0xea00105c = 0xc000000;
 
+	// Reset the ROL state in case it is corrupted by
+	// ARGON_DATA JTAG, a rogue libxenon app, etc.
+	xenon_smc_set_led(0, 0);
+
 	xenon_smc_start_bootanim();
 
 	// flush console after each outputted char


### PR DESCRIPTION
In some situations, the ring of light state might get into a weird state during bootup (most notably because of the ARGON_DATA JTAG method, which my one falcon uses) or when returning to XeLL from a rogue libxenon app.

Resolve by overriding the ROL state to zero before starting the boot animation. This is the same SMC command that my FreeMyXe does for badupdate. 