### PR TITLE
Allow all video modes to be set in the kboot.conf

### DIFF
--- a/kboot.conf
+++ b/kboot.conf
@@ -12,22 +12,24 @@ gateway=192.168.1.1
 ; incase no tftp_server= is set/set invalid/commented, XeLL will use: Supplied address via DHCP, if no DHCP available it will use 192.168.1.98
 tftp_server=192.168.1.99
 
-; XeLL's videomode - valid modes:
-;  0: VIDEO_MODE_VGA_640x480
-;  1: VIDEO_MODE_VGA_1024x768
-;  2: VIDEO_MODE_PAL60
-;  3: VIDEO_MODE_YUV_480P
-;  4: VIDEO_MODE_PAL50
-;  5: VIDEO_MODE_VGA_1280x768
-;  6: VIDEO_MODE_VGA_1360x768
-;  7: VIDEO_MODE_VGA_1280x720
-;  8: VIDEO_MODE_VGA_1440x900
-;  9: VIDEO_MODE_VGA_1280x1024
-; 10: VIDEO_MODE_HDMI_720P
-; 11: VIDEO_MODE_YUV_720P
-; 12: VIDEO_MODE_NTSC
+; Valid video modes, defined in:
+; libxenon/drivers/xenos/xenos_videomodes.h
+; VIDEO_MODE_AUTO          -1
+; VIDEO_MODE_PAL50         0
+; VIDEO_MODE_PAL60         1
+; VIDEO_MODE_NTSC          2
+; VIDEO_MODE_YUV_480P      3
+; VIDEO_MODE_YUV_720P      4
+; VIDEO_MODE_HDMI_720P     5
+; VIDEO_MODE_VGA_640x480   6
+; VIDEO_MODE_VGA_1024x768  7
+; VIDEO_MODE_VGA_1280x720  8
+; VIDEO_MODE_VGA_1280x768  9
+; VIDEO_MODE_VGA_1280x1024 10
+; VIDEO_MODE_VGA_1360x768  11
+; VIDEO_MODE_VGA_1440x900  12
 ; If no value is set/set invalid/commented, XeLL will continue using the autodetected value
-videomode=10
+videomode=5
 
 ; speed up cpu - valid modes:
 ; 1: XENON_SPEED_FULL

--- a/source/lv2/kboot/kbootconf.c
+++ b/source/lv2/kboot/kbootconf.c
@@ -121,7 +121,7 @@ void kboot_set_config(void)
            network_print_config();
         }
         
-        if(conf.videomode > VIDEO_MODE_AUTO && conf.videomode <= VIDEO_MODE_NTSC && oldvideomode != conf.videomode){
+        if(conf.videomode > VIDEO_MODE_AUTO && conf.videomode < VIDEO_MODE_COUNT && oldvideomode != conf.videomode){
             oldvideomode = conf.videomode;
             xenos_init(conf.videomode);
 	    console_init();


### PR DESCRIPTION
kboot.conf currently sets the maximum videomode value to NTSC, effectively meaning we're stuck with PAL/NTSC composite video. VIDEO_MODE_COUNT exists as a constant in libxenon since ~2013, we can reference this value allowing *all* valid video modes to be forced.

I use this to force the video mode to boot ArchPOWER and get a good picture over VGA.