### PR TITLE
Add call to usb_do_poll in the main loop

### DIFF
--- a/source/lv2/main.c
+++ b/source/lv2/main.c
@@ -234,6 +234,7 @@ int main(){
 
 		fileloop();
 		console_clrline();
+		usb_do_poll(); // Refresh USB devices
 	}
 
 	return 0;


### PR DESCRIPTION
Allows users to plug in a drive with a NAND image (or other boot device) after the system has done the initial device enumeration.

XeLL included with older versions of JRunner used to do this, and it's super convenient since you're able to get the CPU key, decrypt the NAND, and flash back without needing to attach a hardware flasher or reboot the machine.