### PR TITLE
Improve README, add build guide, fix compiler warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ dist: clean all
 	@cp stage2.elf32 release/
 	@cp AUTHORS release/
 	@cp CHANGELOG release/
-	@cp README release/
+	@cp README.md release/
 	@cd release; tar czvf XeLL_Reloaded-2stages-$(GITREV).tar.gz *; mv *.tar.gz ..
 	@rm -rf release 
 	@$(MAKE) clean

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-XeLL-Reloaded
+# XeLL-Reloaded
 
-A Xenon Linux loader based on Xell by tmbinc(Felix Domke)
+## A Xenon Linux loader based on Xell by tmbinc(Felix Domke)
 
 XeLL-Reloaded catches CPU threads, sets them up, loads an ELF file from either network (tftp), USB(fat/ext2fs), CDROM (ISO9660) or HDD(fat/ext2fs/xtaf), and launches it. 
 It's made to boot Linux, so it contains a flat device tree for Linux. However, it is able to load other ELF files as well, like applications based on LibXenon.
@@ -29,11 +29,11 @@ It's made to boot Linux, so it contains a flat device tree for Linux. However, i
 * Shows a user controllable menu for the parsed bootentries 
   xell user prompt - by Georg Lukas "Ge0rg" <georg@op-co.de>
 
-  HOW TO USE
-==============
+# HOW TO USE
 
 XeLL Reloaded checks for ELF/UpdXeLL/Kboot-config or updflash.bin in the following order:
 
+```
 USB (FAT/EXT2FS)
 DVD(ISO9660)
 HDD(XTAF/FAT/EXT2FS):	updxell.bin
@@ -52,6 +52,7 @@ Network: 				updxell.bin
 						DHCP supplied bootfile-name
 						* XeLL takes bootserver from DHCP, if supplied. You can supply a static tftpserver ip via kboot.conf. If no tftpserver is found, it falls back to a static ip.
 						* no updflash support via tftp !
+```
 
 
 updflash.bin is a already remapped flashimage/nandimage. 16MB file for 16MB NAND and 64MB file for 64/256/512MB NAND.
@@ -68,16 +69,14 @@ xenon.elf/xenon.z/vmlinux can be either gzipped or bare ELF32 binaries - LINUX o
 There's also a HTTP Server running while XeLL searches for executable binaries.
 It can serve the CPUKey/DVDKey and the console's flashdump.
 
-
-  UPDATING XELL
-=================
+# UPDATING XELL
 
 1. Rename the appropriate XeLL-binary to "updxell.bin". 
 2. Supply the updxell.bin file to XeLL via USB/DVD/HDD or TFTP
 3. It should find the update and flash it
 4. Reboot your Xbox and enjoy the fresh XeLL build
 
-Troubleshooting:
+## Troubleshooting:
 
 updxell.bin doesn't get found / updxell process doesn't start:
 --You have to rebuild your whole hackimage with a recent XeLL. From there on you can use the inbuilt update feature
@@ -85,22 +84,20 @@ updxell function reports that no XeLL binary was found in NAND:
 --Either your XeLL in NAND is too old or it's not a XeLL Reloaded binary - You have to rebuild your whole hackimage with a recent XeLL.
 
 
-  FLASHING NAND
-=================
+# FLASHING NAND
 
 1. Rename the new (already remapped) flashimage to "updflash.bin"
 2. Supply the updflash.bin file to XeLL via USB/DVD/HDD
 3. It should find the update and flash it
 4. Reboot your Xbox and enjoy the new image
 
-Troubleshooting:
+## Troubleshooting:
 
 XBox does not boot properly after flashing the NAND:
 --Either your image wasn't properly remapped or you made something wrong while building the image
 
 
-  USING KBOOT.CONF
-===================
+# USING KBOOT.CONF
 
 1. Read and understand the kboot.conf.sample which is part of every XeLL release with kboot-support
 2. Modify the file to your needs
@@ -125,7 +122,7 @@ XBox does not boot properly after flashing the NAND:
 
 6. Let the bootentry load. Enjoy :)
 
-Troubleshooting:
+## Troubleshooting:
 
 kboot.conf gets found but it doesn't show bootentries or autoloads a bootentry:
 --Make sure timeout is set to something higher than 0

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ updxell.bin doesn't get found / updxell process doesn't start:
 updxell function reports that no XeLL binary was found in NAND:
 --Either your XeLL in NAND is too old or it's not a XeLL Reloaded binary - You have to rebuild your whole hackimage with a recent XeLL.
 
-
 # FLASHING NAND
 
 1. Rename the new (already remapped) flashimage to "updflash.bin"
@@ -95,7 +94,6 @@ updxell function reports that no XeLL binary was found in NAND:
 
 XBox does not boot properly after flashing the NAND:
 --Either your image wasn't properly remapped or you made something wrong while building the image
-
 
 # USING KBOOT.CONF
 
@@ -129,3 +127,22 @@ kboot.conf gets found but it doesn't show bootentries or autoloads a bootentry:
 --Make sure you didn't forget the "" on the bootentry: label="kernelpath params"
 --Also take care of using a texteditor which doesnt automatically break lines if they are too long (will break bootentries), also it shouldn't
 modificate the encoding and lineendings of the config!
+
+# BUILDING
+(Tested with libxenon commit [45d04e8ae307749ce298fc222c528b9bc8e9e5a0](https://github.com/Free60Project/libxenon/commit/45d04e8ae307749ce298fc222c528b9bc8e9e5a0) and Debian 12)
+
+1. Install the libxenon sdk making sure to export the correct environment variables following the [libxenon repository steps](https://github.com/Free60Project/libxenon).
+2. Run `make` in the root of this repository to build all versions of XeLL-Reloaded.
+- To build a specific version of XeLL-Reloaded run `make <target>`. Replace `<target>` with a XeLL-Reloaded option from the list below.
+
+```
+JTAG XeLL:
+xell-1f.bin
+xell-2f.bin
+xell-1f_cygnos_demon.bin
+xell-2f_cygnos_demon.bin
+
+RGH XeLL
+xell-gggggg.bin
+xell-gggggg_cygnos_demon.bin
+```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It's made to boot Linux, so it contains a flat device tree for Linux. However, i
 * Shows a user controllable menu for the parsed bootentries 
   xell user prompt - by Georg Lukas "Ge0rg" <georg@op-co.de>
 
-# HOW TO USE
+# How to use
 
 XeLL Reloaded checks for ELF/UpdXeLL/Kboot-config or updflash.bin in the following order:
 
@@ -69,7 +69,7 @@ xenon.elf/xenon.z/vmlinux can be either gzipped or bare ELF32 binaries - LINUX o
 There's also a HTTP Server running while XeLL searches for executable binaries.
 It can serve the CPUKey/DVDKey and the console's flashdump.
 
-# UPDATING XELL
+# Updating XeLL
 
 1. Rename the appropriate XeLL-binary to "updxell.bin". 
 2. Supply the updxell.bin file to XeLL via USB/DVD/HDD or TFTP
@@ -83,7 +83,7 @@ updxell.bin doesn't get found / updxell process doesn't start:
 updxell function reports that no XeLL binary was found in NAND:
 --Either your XeLL in NAND is too old or it's not a XeLL Reloaded binary - You have to rebuild your whole hackimage with a recent XeLL.
 
-# FLASHING NAND
+# Flashing NAND
 
 1. Rename the new (already remapped) flashimage to "updflash.bin"
 2. Supply the updflash.bin file to XeLL via USB/DVD/HDD
@@ -95,7 +95,7 @@ updxell function reports that no XeLL binary was found in NAND:
 XBox does not boot properly after flashing the NAND:
 --Either your image wasn't properly remapped or you made something wrong while building the image
 
-# USING KBOOT.CONF
+# Using kboot.conf
 
 1. Read and understand the kboot.conf.sample which is part of every XeLL release with kboot-support
 2. Modify the file to your needs
@@ -128,21 +128,13 @@ kboot.conf gets found but it doesn't show bootentries or autoloads a bootentry:
 --Also take care of using a texteditor which doesnt automatically break lines if they are too long (will break bootentries), also it shouldn't
 modificate the encoding and lineendings of the config!
 
-# BUILDING
-(Tested with libxenon commit [45d04e8ae307749ce298fc222c528b9bc8e9e5a0](https://github.com/Free60Project/libxenon/commit/45d04e8ae307749ce298fc222c528b9bc8e9e5a0) and Debian 12)
-
+# Building
 1. Install the libxenon sdk making sure to export the correct environment variables following the [libxenon repository steps](https://github.com/Free60Project/libxenon).
 2. Run `make` in the root of this repository to build all versions of XeLL-Reloaded.
 - To build a specific version of XeLL-Reloaded run `make <target>`. Replace `<target>` with a XeLL-Reloaded option from the list below.
 
-```
-JTAG XeLL:
-xell-1f.bin
-xell-2f.bin
-xell-1f_cygnos_demon.bin
-xell-2f_cygnos_demon.bin
+* RGH XeLL: `xell-gggggg.bin`
+* JTAG/BadUpdate XeLL: `xell-2f.bin`
+    * Old-style JTAG images: `xell-1f.bin`
 
-RGH XeLL
-xell-gggggg.bin
-xell-gggggg_cygnos_demon.bin
-```
+For other varients of XeLL-Reloaded please refer to the [Makefile](/Makefile)

--- a/source/lv1/cache.S
+++ b/source/lv1/cache.S
@@ -11,7 +11,7 @@ dcache_flush:
 	add %r4, %r4, %r3
 
 1:
-	dcbst %r0, %r5
+	dcbst 0, %r5
 	addic %r5, %r5, CACHELINE_SIZE /* also clears carry */
 	subic. %r4, %r4, CACHELINE_SIZE
 	bge 1b
@@ -28,7 +28,7 @@ dcache_inv:
 	add %r4, %r4, %r3
 
 1:
-	dcbf %r0, %r5
+	dcbf 0, %r5
 	addic %r5, %r5, CACHELINE_SIZE /* also clears carry */
 	subic. %r4, %r4, CACHELINE_SIZE
 	bge 1b
@@ -45,8 +45,8 @@ flush_code:
 	add %r4, %r4, %r3
 
 1:
-	dcbst %r0, %r5
-	icbi %r0, %r5
+	dcbst 0, %r5
+	icbi 0, %r5
 	addic %r5, %r5, CACHELINE_SIZE /* also clears carry */
 	subic. %r4, %r4, CACHELINE_SIZE
 	bge 1b

--- a/source/lv2/mount.c
+++ b/source/lv2/mount.c
@@ -198,8 +198,8 @@ static void AddPartition(sec_t sector, int device, int type, int *devnum) {
 		return;	
 	}
 
-	char mount[10];
-	sprintf(mount, "%s%i", prefix[device], *devnum);
+	char mount[16];
+	snprintf(mount, sizeof(mount), "%s%i", prefix[device], *devnum);
 	char *name;
 
 	switch (type) {


### PR DESCRIPTION
I've turned the original readme into a markdown file and added proper headings and subheadings to it to make it a bit clearer to read through. I've also added a simple build guide at the bottom of the readme if people are wanting to build Xell-Reloaded themselves. Finally I got rid of 2 compiler warnings, one in `source/lv1/cache.S`, and the other in `source/lv2/mount.c`.