### PR TITLE
Add the console type to the XeLL startup 

### DIFF
--- a/source/lv2/main.c
+++ b/source/lv2/main.c
@@ -38,6 +38,19 @@
 
 #include "log.h"
 
+static const char *consoleNames[] =
+{
+	"Xenon",
+	"Zephyr",
+	"Falcon",
+	"Jasper",
+	"Trinity",
+	"Corona",
+	"Corona MMC",
+	"Winchester",
+	"Winchester MMC",
+};
+
 void do_asciiart()
 {
 	char *p = asciiart;
@@ -89,6 +102,7 @@ void synchronize_timebases()
 int main(){
 	LogInit();
 	int i;
+	int consoleType = 0;
 
 	printf("ANA Dump before Init:\n");
 	dumpana();
@@ -179,7 +193,11 @@ int main(){
 	/*int device_list_size = */ // findDevices();
 
 	/* display some cpu info */
-	printf(" * CPU PVR: %08x\n", mfspr(287));
+	consoleType = xenon_get_console_type();
+
+	printf("\n * Console Type: %s (PVR %08x)\n\n",
+			 (consoleType >= 0 && consoleType <= 7) ? consoleNames[consoleType] : "Unknown",
+			 mfspr(287));
 
 #ifndef NO_PRINT_CONFIG
 	printf(" * FUSES - write them down and keep them safe:\n");


### PR DESCRIPTION
Now that libxenon is able to tell xenon and zephyr apart, xenon_get_console_type output is useful to include in the xell startup output. 

This PR replaces the `CPU PVR` line in the with a `Console Type` line that prints both the console type as reported by libxenon and the PVR on one line.

<img width="2048" height="1536" alt="IMG_6103" src="https://github.com/user-attachments/assets/21288c7b-451f-4b5a-b227-60346dbfb147" />
